### PR TITLE
Fix getting wrong attribute from stanza

### DIFF
--- a/src/xmppipe.c
+++ b/src/xmppipe.c
@@ -791,7 +791,7 @@ handle_version(xmpp_conn_t * const conn, xmpp_stanza_t * const stanza,
     xmppipe_stanza_set_name(reply, "iq");
     xmppipe_stanza_set_type(reply, "result");
 
-    id = xmpp_stanza_get_attribute(stanza, "from");
+    id = xmpp_stanza_get_attribute(stanza, "id");
     if (id == NULL)
         return 1;
 


### PR DESCRIPTION
Also check new functions from libstrophe-0.9.0: `xmpp_stanza_{get,set}_{to,from}`, `xmpp_stanza_reply`, `xmpp_iq_new`, etc. They are just wrappers for common usecases.